### PR TITLE
ホスト名に応じて出題数プルダウンを制限

### DIFF
--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -24,6 +24,17 @@ let advanceTimerId = null;
 let elapsedTimerId = null;
 let currentScreen = 'start';
 let settingsReturnScreen = 'start';
+const LOCAL_HOSTNAMES = ['localhost', '127.0.0.1', '::1'];
+
+function isLocalHostname(hostname) {
+  const host = (hostname || '').toLowerCase();
+  return LOCAL_HOSTNAMES.includes(host);
+}
+
+function getAvailableQuestionCountValues() {
+  if (!elements.questionCount) return [];
+  return Array.from(elements.questionCount.options).map(opt => opt.value);
+}
 
 function readLocalSetting(key, fallback) {
   try {
@@ -46,21 +57,27 @@ function writeLocalSetting(key, value) {
 function applyQuestionCount(value) {
   if (!elements.questionCount) return;
 
-  if (value === 'weak5') {
+  const availableValues = getAvailableQuestionCountValues();
+  const numericOptions = availableValues.filter(v => v !== 'weak5');
+  const defaultValue = numericOptions[numericOptions.length - 1] || '20';
+
+  if (value === 'weak5' && availableValues.includes('weak5')) {
     elements.questionCount.value = 'weak5';
     quizState.questionLimit = 5;
     return;
   }
 
   const val = parseInt(value, 10);
-  if (Number.isFinite(val) && val >= 1 && val <= 20) {
-    elements.questionCount.value = String(val);
+  const valueStr = Number.isFinite(val) ? String(val) : '';
+  if (valueStr && availableValues.includes(valueStr) && val >= 1 && val <= 20) {
+    elements.questionCount.value = valueStr;
     quizState.questionLimit = val;
     return;
   }
 
-  elements.questionCount.value = '20';
-  quizState.questionLimit = 20;
+  elements.questionCount.value = defaultValue;
+  const fallback = parseInt(defaultValue, 10);
+  quizState.questionLimit = Number.isFinite(fallback) ? fallback : 20;
 }
 
 function loadStartSettings() {
@@ -164,6 +181,28 @@ function updateWeak5Option(color) {
     elements.questionCount.value = '20';
     quizState.questionLimit = 20;
   }
+}
+
+function setupQuestionCountOptions() {
+  if (!elements.questionCount) return;
+
+  const hostname = window.location?.hostname || '';
+  const numericValues = isLocalHostname(hostname)
+    ? Array.from({ length: 20 }, (_, idx) => String(idx + 1))
+    : ['20'];
+
+  const optionsHtml = numericValues.map(val => {
+    const isSelected = String(quizState.questionLimit) === val;
+    return `<option value="${val}" ${isSelected ? 'selected' : ''}>${val} 問</option>`;
+  }).join('');
+  const weak5Option = '<option value="weak5" disabled>苦手5種</option>';
+  elements.questionCount.innerHTML = optionsHtml + weak5Option;
+
+  const defaultValue = numericValues.includes(String(quizState.questionLimit))
+    ? String(quizState.questionLimit)
+    : (numericValues[0] || '20');
+  elements.questionCount.value = defaultValue;
+  quizState.questionLimit = parseInt(defaultValue, 10) || 20;
 }
 
 function resetOptionButtons() {
@@ -738,18 +777,7 @@ function initEventHandlers() {
 
   if (elements.questionCount) {
     elements.questionCount.addEventListener('change', () => {
-      const selectedValue = elements.questionCount.value;
-      if (selectedValue === 'weak5') {
-        quizState.questionLimit = 5;
-      } else {
-        const val = parseInt(selectedValue, 10);
-        if (Number.isFinite(val) && val >= 1 && val <= 20) {
-          quizState.questionLimit = val;
-        } else {
-          quizState.questionLimit = 20;
-          elements.questionCount.value = 20;
-        }
-      }
+      applyQuestionCount(elements.questionCount.value);
       writeLocalSetting(STORAGE_KEYS.QUESTION_COUNT, elements.questionCount.value);
     });
   }
@@ -950,15 +978,7 @@ function init() {
   if (elements.version) {
     elements.version.textContent = APP_VERSION;
   }
-  if (elements.questionCount) {
-    const normalOptions = Array.from({ length: 20 }, (_, idx) => {
-      const val = idx + 1;
-      return `<option value="${val}" ${val === quizState.questionLimit ? 'selected' : ''}>${val} 問</option>`;
-    }).join('');
-    const weak5Option = '<option value="weak5" disabled>苦手5種</option>';
-    elements.questionCount.innerHTML = normalOptions + weak5Option;
-    elements.questionCount.value = quizState.questionLimit;
-  }
+  setupQuestionCountOptions();
   loadStartSettings();
   loadSettingsValues();
 

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -164,6 +164,28 @@ describe('app', () => {
     vi.useRealTimers();
   });
 
+  it('limits question options to 20 and weak5 on non-localhost hosts', async () => {
+    const originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      value: new URL('https://example.com/'),
+      writable: true,
+    });
+
+    await import('../docs/js/app.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    await flushPromises();
+
+    const questionCount = document.getElementById('question-count');
+    const optionValues = Array.from(questionCount.options).map(opt => opt.value);
+    expect(optionValues).toEqual(['20', 'weak5']);
+    expect(questionCount.value).toBe('20');
+
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+    });
+  });
+
   it('starts quiz and auto-advances on correct answer', async () => {
     vi.useFakeTimers();
     await import('../docs/js/app.js');


### PR DESCRIPTION
## 目的
- localhost 以外の環境では出題数を 20 問または苦手 5 問に限定し、公開環境での利用を想定した出題数の選択肢に絞るため。

## 主な変更
- ホスト名を判定して出題数プルダウンの選択肢を生成し、localhost 以外では 20 問と苦手 5 問のみを表示するように修正。
- 利用可能な選択肢に基づいて出題数設定を適用・補正する処理を追加し、無効な値が選択された場合に安全にフォールバックするように改善。
- ホスト名による出題数制限が効いていることを確認するテストを追加。

## 動作確認
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69532fa8d08c832bbaa68504670b725b)