### PR TITLE
fix: スマートフォン縦長画面での操作問題を修正

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -941,7 +941,7 @@ body {
 }
 
 /* Ensure footer links are clickable above fixed bottom ads */
-footer {
+footer a {
   position: relative;
   z-index: 10001;
 }


### PR DESCRIPTION
フッター全体ではなく、フッター内のリンクだけにz-indexを適用することで、
画面下半分の操作をブロックしていた問題を解決。
プライバシーポリシーなどのリンクは引き続きクリック可能。