### PR TITLE
fix: 広告領域とフッターのz-indexスタイルを削除

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -474,33 +474,6 @@ h6,
   }
 }
 
-/* ==================== Ad Banner Styles ==================== */
-/* Fixed bottom banner with safe-area adjustments */
-.ad-wrapper {
-  position: fixed;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding: env(safe-area-inset-bottom, 12px) 8px;
-  z-index: 9999;
-  pointer-events: auto;
-}
-
-.ad-banner {
-  max-width: 1000px;
-  width: 100%;
-  height: auto;
-  display: block !important;
-}
-
-/* Reserve space for the fixed banner so page content isn't hidden behind it */
-body {
-  padding-bottom: 88px; /* adjust if your banner height differs */
-}
-
 /* Toggle Buttons (Settings) */
 .btn-toggle {
   background: transparent;
@@ -938,10 +911,4 @@ body {
   .session-result {
     align-self: flex-end;
   }
-}
-
-/* Ensure footer links are clickable above fixed bottom ads */
-footer a {
-  position: relative;
-  z-index: 10001;
 }

--- a/src/index.html
+++ b/src/index.html
@@ -12,8 +12,6 @@
     href="https://fonts.googleapis.com/css2?family=Zen+Kaku+Gothic+New:wght@400;500;700&family=Zen+Old+Mincho:wght@400;500;600;700&display=swap"
     rel="stylesheet">
   <link rel="stylesheet" href="css/style.css">
-  <!-- Google AdSense / AdMob: replace `ca-pub-XXXXXXXXXXXX` with your publisher ID -->
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2700375895626639" crossorigin="anonymous"></script>
 </head>
 
 <body class="page-shell">
@@ -290,17 +288,6 @@
   <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   <script type="module" src="js/app.js"></script>
-  <!-- Bottom banner ad (AdSense / AdMob via AdSense for web). Replace data-ad-client and data-ad-slot before deploy. -->
-  <div class="ad-wrapper" aria-hidden="true">
-    <!-- Example responsive banner. Update `data-ad-client` and `data-ad-slot`. -->
-    <ins class="adsbygoogle ad-banner"
-      style="display:block"
-      data-ad-client="ca-pub-2700375895626639"
-      data-ad-slot="8823894616"
-      data-ad-format="auto"
-      data-full-width-responsive="true"></ins>
-    <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
-  </div>
 </body>
 
 </html>


### PR DESCRIPTION
スマートフォン縦長画面での操作問題を解決するため、
広告関連のコード（CSS、HTML）とフッターのz-indexスタイルを完全に削除。
広告については改めて対応を検討する。