### PR TITLE
feat: 統計ページの苦手な決まり字を全件表示し、回答時間でソート

### DIFF
--- a/src/js/stats-ui.js
+++ b/src/js/stats-ui.js
@@ -167,20 +167,20 @@ export function createStatsUI({
 
     html += `
       <div class="detail-section">
-        <h5>苦手な決まり字トップ5</h5>
+        <h5>苦手な決まり字</h5>
         <div class="kimariji-stats">
     `;
 
-    const top5 = detailedStats.kimarijiStats.slice(0, 5);
-    if (top5.length === 0 || top5.every(k => k.total === 0)) {
+    const kimarijiList = detailedStats.kimarijiStats.filter(k => k.total > 0);
+    if (kimarijiList.length === 0) {
       html += `<p class="text-muted">まだデータがありません</p>`;
     } else {
-      top5.forEach(k => {
-        if (k.total === 0) return;
+      kimarijiList.forEach(k => {
+        const avgTimeText = k.avgTimeMs !== null ? ` / 平均${formatDurationMs(k.avgTimeMs)}` : '';
         html += `
           <div class="kimariji-item">
             <div class="kimariji-text">${k.kimariji}</div>
-            <div class="kimariji-rate">${k.rate}% (${k.correct}/${k.total})</div>
+            <div class="kimariji-rate">${k.rate}% (${k.correct}/${k.total})${avgTimeText}</div>
           </div>
         `;
       });

--- a/src/js/stats.js
+++ b/src/js/stats.js
@@ -83,7 +83,7 @@ export function calculateKimarijiPerformance(color, poems, history) {
   colorPoems.forEach(poem => {
     const kimariji = poem.kimarijiShort || poem.kimarijiLong || '決まり字なし';
     if (kimariji && !kimarijiMap.has(kimariji)) {
-      kimarijiMap.set(kimariji, { correct: 0, total: 0 });
+      kimarijiMap.set(kimariji, { correct: 0, total: 0, totalTimeMs: 0, timeCount: 0 });
     }
   });
 
@@ -96,6 +96,10 @@ export function calculateKimarijiPerformance(color, poems, history) {
           if (answer.isCorrect) {
             stats.correct++;
           }
+          if (answer.answerTimeMs != null && Number.isFinite(answer.answerTimeMs)) {
+            stats.totalTimeMs += answer.answerTimeMs;
+            stats.timeCount++;
+          }
         }
       });
     }
@@ -105,14 +109,20 @@ export function calculateKimarijiPerformance(color, poems, history) {
     kimariji,
     correct: stats.correct,
     total: stats.total,
-    rate: stats.total > 0 ? Math.round((stats.correct / stats.total) * 100) : 0
+    rate: stats.total > 0 ? Math.round((stats.correct / stats.total) * 100) : 0,
+    avgTimeMs: stats.timeCount > 0 ? Math.round(stats.totalTimeMs / stats.timeCount) : null
   }));
 
   kimarijiStats.sort((a, b) => {
     if (a.total === 0 && b.total === 0) return 0;
     if (a.total === 0) return 1;
     if (b.total === 0) return -1;
-    return a.rate - b.rate;
+    if (a.rate !== b.rate) return a.rate - b.rate;
+    // 正答率が同じ場合、平均回答時間が長い方を苦手と判断（降順）
+    if (a.avgTimeMs === null && b.avgTimeMs === null) return 0;
+    if (a.avgTimeMs === null) return 1;
+    if (b.avgTimeMs === null) return -1;
+    return b.avgTimeMs - a.avgTimeMs;
   });
 
   return kimarijiStats;

--- a/tests/stats.test.js
+++ b/tests/stats.test.js
@@ -104,9 +104,9 @@ describe('stats', () => {
       {
         color: '青',
         answers: [
-          { kimariji: 'あ', isCorrect: true },
-          { kimariji: 'あ', isCorrect: false },
-          { kimariji: 'い', isCorrect: false },
+          { kimariji: 'あ', isCorrect: true, answerTimeMs: 2000 },
+          { kimariji: 'あ', isCorrect: false, answerTimeMs: 3000 },
+          { kimariji: 'い', isCorrect: false, answerTimeMs: 4000 },
         ],
       },
     ];
@@ -115,8 +115,10 @@ describe('stats', () => {
     expect(result).toHaveLength(2);
     expect(result[0].kimariji).toBe('い');
     expect(result[0].rate).toBe(0);
+    expect(result[0].avgTimeMs).toBe(4000);
     expect(result[1].kimariji).toBe('あ');
     expect(result[1].rate).toBe(50);
+    expect(result[1].avgTimeMs).toBe(2500);
   });
 
   it('calculateKimarijiPerformance sorts totals with zero last', () => {
@@ -125,11 +127,13 @@ describe('stats', () => {
       { color: '青', kimarijiShort: 'あ', kimarijiLong: '', shimoNoKu: '', shimoReading: '', kamiNoKu: '', kamiReading: '' },
     ];
     const history = [
-      { color: '青', answers: [{ kimariji: 'あ', isCorrect: true }] },
+      { color: '青', answers: [{ kimariji: 'あ', isCorrect: true, answerTimeMs: 1000 }] },
     ];
     const result = calculateKimarijiPerformance('青', poems, history);
     expect(result[0].kimariji).toBe('あ');
+    expect(result[0].avgTimeMs).toBe(1000);
     expect(result[1].kimariji).toBe('い');
+    expect(result[1].avgTimeMs).toBe(null);
   });
 
   it('calculateKimarijiPerformance keeps order when totals are zero', () => {
@@ -142,6 +146,42 @@ describe('stats', () => {
     expect(result[1].kimariji).toBe('い');
     expect(result[0].total).toBe(0);
     expect(result[1].total).toBe(0);
+    expect(result[0].avgTimeMs).toBe(null);
+    expect(result[1].avgTimeMs).toBe(null);
+  });
+
+  it('calculateKimarijiPerformance sorts by avgTimeMs when rate is same', () => {
+    const poems = [
+      { color: '青', kimarijiShort: 'あ', kimarijiLong: '', shimoNoKu: '', shimoReading: '', kamiNoKu: '', kamiReading: '' },
+      { color: '青', kimarijiShort: 'い', kimarijiLong: '', shimoNoKu: '', shimoReading: '', kamiNoKu: '', kamiReading: '' },
+      { color: '青', kimarijiShort: 'う', kimarijiLong: '', shimoNoKu: '', shimoReading: '', kamiNoKu: '', kamiReading: '' },
+    ];
+    const history = [
+      {
+        color: '青',
+        answers: [
+          { kimariji: 'あ', isCorrect: true, answerTimeMs: 5000 },
+          { kimariji: 'あ', isCorrect: false, answerTimeMs: 6000 },
+          { kimariji: 'い', isCorrect: true, answerTimeMs: 2000 },
+          { kimariji: 'い', isCorrect: false, answerTimeMs: 3000 },
+          { kimariji: 'う', isCorrect: true, answerTimeMs: 8000 },
+          { kimariji: 'う', isCorrect: false, answerTimeMs: 9000 },
+        ],
+      },
+    ];
+
+    const result = calculateKimarijiPerformance('青', poems, history);
+    expect(result).toHaveLength(3);
+    // すべて正答率50%なので、平均回答時間の長い順（降順）にソート
+    expect(result[0].kimariji).toBe('う');
+    expect(result[0].rate).toBe(50);
+    expect(result[0].avgTimeMs).toBe(8500);
+    expect(result[1].kimariji).toBe('あ');
+    expect(result[1].rate).toBe(50);
+    expect(result[1].avgTimeMs).toBe(5500);
+    expect(result[2].kimariji).toBe('い');
+    expect(result[2].rate).toBe(50);
+    expect(result[2].avgTimeMs).toBe(2500);
   });
 
   it('calculateRecentTrend detects improving trend', () => {


### PR DESCRIPTION
- トップ5の制限を削除し、全ての苦手な決まり字を表示
- 平均回答時間を計算し、UIに表示
- 正答率が同じ場合、平均回答時間が長い方を苦手と判断
- テストケースを追加・更新